### PR TITLE
make adapter work cross-os, fix errors, add/update testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 before_script:
-  - npm install winston@2.3.0
+  - npm install winston@2.3.1
   - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
 env:
   - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - "8"
 before_script:
   - npm install winston@2.3.1
-  - npm install https://github.com/Apollon77ioBroker.js-controller/tarball/master --production
+  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
   - "8"
 before_script:
   - npm install winston@2.3.1
-  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+  - npm install https://github.com/Apollon77ioBroker.js-controller/tarball/master --production
 env:
   - CXX=g++-4.8
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"
+    - nodejs_version: "8"
 
 platform:
   - x86
@@ -17,7 +18,7 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   # install modules
   - npm install
-  - npm install winston@2.3.0
+  - npm install winston@2.3.1
   - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   # install modules
   - npm install
   - npm install winston@2.3.1
-  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+  - npm install https://github.com/Apollon77/ioBroker.js-controller/tarball/master --production
 
 # Post-install test scripts.
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   # install modules
   - npm install
   - npm install winston@2.3.1
-  - npm install https://github.com/Apollon77/ioBroker.js-controller/tarball/master --production
+  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
 
 # Post-install test scripts.
 test_script:

--- a/js2fs.js
+++ b/js2fs.js
@@ -9,7 +9,7 @@ const
     soef = require('soef'),
     path = require('path'),
     fs = require('fs'),
-    chokidar = require('chokidar');
+    chokidar = require('chokidar'),
     child_process = require('child_process')
 ;
 

--- a/js2fs.js
+++ b/js2fs.js
@@ -556,7 +556,7 @@ let watcher = {
                 return;
             }
 
-            if (eventType === 'add' || eventType === 'addDir') {
+            if (eventType === 'addDir') {
                 console.log('watch: ' + eventType + ' - ' + filename + ' type ignored');
                 return;
             }
@@ -566,13 +566,19 @@ let watcher = {
                 return;
             }
             console.log ('watch: ' + eventType + ' - ' + filename);
-            filename = path.sep + filename;
-            let fullfn = adapter.config.rootDir.fullFn (filename);
+
+            let fullfn = filename;
+            if (filename.indexOf(adapter.config.rootDir) === 0) filename = filename.substring(adapter.config.rootDir.length);
+            if (filename[0] !== path.sep) filename = path.sep + filename;
             let file = getFileObject(fullfn);
             if (!file || file.source === false) {
                 //return scripts.delete(filename);
             } else {
                 let obj = scripts.fn2obj(filename);
+                if (obj && eventType === 'add') {
+                    console.log('watch: ' + eventType + ' - ' + filename + ' ignored, because already exists');
+                    return;
+                }
                 let cmd = (file.source.match(/^[\/\s]*!!([\S]*)/) || []) [1] || 0;
                 let ar = cmd.match(/^(.*?)=(.*?)$/);
                 if (ar && ar[1]) cmd = ar[1];
@@ -607,6 +613,7 @@ let watcher = {
                         break;
 
                     default:
+                        adapter.log.debug('file changed ' + filename);
                         scripts.change(filename, file.source, file.mtime);
                         break;
                 }

--- a/js2fs.js
+++ b/js2fs.js
@@ -579,7 +579,7 @@ let watcher = {
                     console.log('watch: ' + eventType + ' - ' + filename + ' ignored, because already exists');
                     return;
                 }
-                let cmd = (file.source.match(/^[\/\s]*!!([\S]*)/) || []) [1] || 0;
+                let cmd = (file.source.match(/^[\/\s]*!!([\S]*)/) || []) [1] || [0];
                 let ar = cmd.match(/^(.*?)=(.*?)$/);
                 if (ar && ar[1]) cmd = ar[1];
                 switch (cmd) {

--- a/js2fs.js
+++ b/js2fs.js
@@ -33,15 +33,11 @@ let reRootDir, logFilter, copyLog;
 let logTimer = soef.Timer();
 
 noext = killext = function (fn) {
-    let ext = path.extname(fn);
-    if (ext.length > 0) {
-        fn = fn.substring(0,fn.length-ext.length);
-    }
-    return fn; //fn.replace(/\.[^.]*?$/, '');
+    return fn.noext(); //fn.replace(/\.[^.]*?$/, '');
 };
 function justPathname(fn) {
     //return fn.replace(/(.*)\\.*?$/, '$1');
-    return path.dirname(fn);
+    return fn.justPathname();
 }
 String.prototype.fullFn = function (fn) {
     if (!fn) return adapter.config.rootDir.fullFn(this);
@@ -65,6 +61,7 @@ String.prototype.noext = function () {
 String.prototype.justPathname = function () {
     //return this.replace(/(.*)\\.*?$/, '$1');
     //return this.replace(/\\[^\\]*?$/, '');
+    if (this.noext() === this) return this;
     return path.dirname(this);
 };
 String.prototype.withoutRoot = function () {
@@ -740,7 +737,7 @@ function checkJavascriptAdapter(callback) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 function normalizeConfig(config) {
-    config.rootDir = path.dirname(config.rootDir); //.remove(/\\$/);
+    config.rootDir = config.rootDir; //.remove(/\\$/);
     if (config.port === undefined) config.port = 21;
     if (config.useGlobalScriptAsPrefix === undefined) config.useGlobalScriptAsPrefix = true;
     if (config.restartScript === undefined) config.restartScript = true;
@@ -751,7 +748,7 @@ function normalizeConfig(config) {
 function watchLog () {
     if (!adapter.config.ioBrokerRootdir) return;
     let date = new Date();
-    let fn = path.join(path.dirname(adapter.config.ioBrokerRootdir), 'log', soef.sprintf('iobroker.%d-%02d-%02d.log', date.getFullYear(), date.getMonth()+1, date.getDate()));
+    let fn = path.join(adapter.config.ioBrokerRootdir, 'log', soef.sprintf('iobroker.%d-%02d-%02d.log', date.getFullYear(), date.getMonth()+1, date.getDate()));
 
     fs.watchFile(fn, (curr, prev) => {
         copyLog();

--- a/js2fs.js
+++ b/js2fs.js
@@ -607,7 +607,7 @@ let watcher = {
                         break;
                 }
             }
-        }
+        });
     },
     restart: this.run,
 };

--- a/js2fs.js
+++ b/js2fs.js
@@ -282,7 +282,7 @@ let Scripts = function () {
 
             scripts.forEach(function (o, i) {
                 let id, path;
-                id = o.id.noext(); //replace(/(.*)\..*?$/, '$1');
+                id = o.id; //replace(/(.*)\..*?$/, '$1');
                 o.fn = o.fn || buildFilename(o); //o.id.replace(reScriptJs, '').replace(/\./g, '\\') + '.js';
                 path = o.fn; //id.replace(reScriptJs, '').replace(/\./g, '\\') || '\\';
                 add(o);

--- a/js2fs.js
+++ b/js2fs.js
@@ -818,6 +818,6 @@ function main() {
     start();
 
     adapter.subscribeStates('*');
-    adapter.subscribeForeignObjects('*');
+    adapter.subscribeForeignObjects('script.js.*');
     //});
 }

--- a/js2fs.js
+++ b/js2fs.js
@@ -75,7 +75,7 @@ String.prototype.toFn = String.prototype.toFilename = String.prototype.id2fn = f
     let ext = reSettings.test(this) ? '.json' : '.js';
     let fn = this.remove(reScriptJsDot);
     let fnArr = fn.split('.');
-    fn = path.join(fnArr); //.replace(/\./g, '\\');
+    fn = pathJoinArr(fnArr); //.replace(/\./g, '\\');
     //let ret = adapter.config.rootDir.fullFn(this.remove(reScriptJsDot).replace(/\./g, '\\'));
     //ret += '.js';
     return adapter.config.rootDir.fullFn(fn + ext);
@@ -85,6 +85,14 @@ Date.prototype.getUnixTime = Date.prototype.getCTime = function () {
     //return parseInt(this.getTime() / 1000);
     return ~~(this.getTime() / 1000);
 };
+
+function pathJoinArr(arr) {
+    let res = '';
+    arr.forEach(function(element) {
+        res = path.join(res, element);
+    });
+    return res;
+}
 
 let adapter = soef.Adapter(
     main,
@@ -265,7 +273,7 @@ let Scripts = function () {
             function buildFilename(o) {
                 let fn = o.id.remove(reScriptJsDot);
                 let fnArr = fn.split('.');
-                return path.sep + path.join(fnArr) + ext(o);
+                return path.sep + pathJoinArr(fnArr) + ext(o);
             }
 
             function add(o) {
@@ -742,7 +750,7 @@ function normalizeConfig(config) {
 function watchLog () {
     if (!adapter.config.ioBrokerRootdir) return;
     let date = new Date();
-    let fn = path.join(path.dirname(adapter.config.ioBrokerRootdir),'log', soef.sprintf('iobroker.%d-%02d-%02d.log', date.getFullYear(), date.getMonth()+1, date.getDate()));
+    let fn = path.join(path.dirname(adapter.config.ioBrokerRootdir), 'log', soef.sprintf('iobroker.%d-%02d-%02d.log', date.getFullYear(), date.getMonth()+1, date.getDate()));
 
     fs.watchFile(fn, (curr, prev) => {
         copyLog();

--- a/js2fs.js
+++ b/js2fs.js
@@ -818,6 +818,6 @@ function main() {
     start();
 
     adapter.subscribeStates('*');
-    adapter.subscribeForeignObjects('script.js.*');
+    adapter.subscribeForeignObjects('*');
     //});
 }

--- a/js2fs.js
+++ b/js2fs.js
@@ -581,7 +581,7 @@ let watcher = {
                 }
                 let cmdRes = file.source.match(/^[\/\s]*!!([\S]*)/);
                 let cmd = '';
-                if (cmdRes[1]) cmd = cmdRes[1];
+                if (cmdRes && cmdRes[1]) cmd = cmdRes[1];
                 let ar = cmd.match(/^(.*?)=(.*?)$/);
                 if (ar && ar[1]) cmd = ar[1];
                 switch (cmd) {

--- a/js2fs.js
+++ b/js2fs.js
@@ -579,7 +579,9 @@ let watcher = {
                     console.log('watch: ' + eventType + ' - ' + filename + ' ignored, because already exists');
                     return;
                 }
-                let cmd = (file.source.match(/^[\/\s]*!!([\S]*)/) || []) [1] || [0];
+                let cmdRes = file.source.match(/^[\/\s]*!!([\S]*)/);
+                let cmd = '';
+                if (cmdRes[1]) cmd = cmdRes[1];
                 let ar = cmd.match(/^(.*?)=(.*?)$/);
                 if (ar && ar[1]) cmd = ar[1];
                 switch (cmd) {

--- a/js2fs.js
+++ b/js2fs.js
@@ -9,6 +9,7 @@ const
     soef = require('soef'),
     path = require('path'),
     fs = require('fs'),
+    chokidar = require('chokidar');
     child_process = require('child_process')
 ;
 
@@ -544,8 +545,11 @@ let watcher = {
     run: function () {
         let self = this;
         this.close();
-        this.handle = fs.watch(adapter.config.rootDir, { recursive: true }, function (eventType, filename) {
-
+        //this.handle = fs.watch(adapter.config.rootDir, { recursive: true }, function (eventType, filename) {
+        this.handle = chokidar.watch(adapter.config.rootDir, {
+            ignored: /(^|[\/\\])\../,
+            persistent: true
+        }). on('all', function (eventType, filename, details) {
             if (self.cnt) {
                 self.cnt -= 1;
                 adapter.log.debug('watch: event ignored! cnt=' + self.cnt + ' - ' + eventType + ' - ' + filename);
@@ -603,7 +607,7 @@ let watcher = {
                         break;
                 }
             }
-        });
+        }
     },
     restart: this.run,
 };

--- a/js2fs.js
+++ b/js2fs.js
@@ -556,6 +556,10 @@ let watcher = {
                 return;
             }
 
+            if (eventType === 'add' || eventType === 'addDir') {
+                console.log('watch: ' + eventType + ' - ' + filename + ' type ignored');
+                return;
+            }
             //jetbrians temp filename: \global\Global_global.js___jb_tmp___
             if (!filename || !/\.js$|\.json$/.test(filename)) {
                 console.log('watch: ' + eventType + ' - ' + filename + ' ignored');

--- a/js2fs.js
+++ b/js2fs.js
@@ -46,7 +46,8 @@ function justPathname(fn) {
 String.prototype.fullFn = function (fn) {
     if (!fn) return adapter.config.rootDir.fullFn(this);
     //if (/^\\\\|^.\:\\/.test(fn) || fn.substring(0,1) === '/') return fn;
-    if (path.isAbsolute(fn)) return fn;
+    //if (path.isAbsolute(fn)) return fn;
+    if (fn.substring(adapter.config.rootDir) === 0) return fn;
     return path.normalize(path.join(this, fn)); // (this + '\\' + fn).replace(/[\\]{2,}/g, '\\');
 };
 String.prototype.remove = function (regex) {

--- a/js2fs.js
+++ b/js2fs.js
@@ -305,8 +305,8 @@ let Scripts = function () {
     let getmtime = function (fn, common) {
         let stat = soef.lstatSync(adapter.config.rootDir.fullFn(fn));
         if (stat && stat.mtime) {
-            adapter.log.debug('get mtime: ' + stat.mtime);
-            common.mtime = stat.mtime;
+            adapter.log.debug('get mtime: ' + stat.mtime.getUnixTime());
+            common.mtime = stat.mtime.getUnixTime();
         }
     };
 
@@ -397,9 +397,9 @@ let Scripts = function () {
         }
         soef.modifyObject(id, function (o) {
             o.common.source = source;
-            obj.common.source = source;
-            obj.common.mtime = mtime;
-            if (!mtime) getmtime(fn, o.common);
+            //obj.common.source = source;
+            if (mtime) o.common.mtime = mtime;
+                else getmtime(fn, o.common);
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;
@@ -508,7 +508,8 @@ function getFileObject(fn) {
     let stat = soef.lstatSync(fn);
     obj.source = soef.readFileSync(fn);
     if (obj.source) obj.source = obj.source.toString();
-    obj.mtime = stat.mtime;
+    obj.mtime = stat.mtime.getUnixTime();
+    adapter.log.debug('mtime of FileObject ' + stat.mtime);
     return obj;
 }
 

--- a/js2fs.js
+++ b/js2fs.js
@@ -162,7 +162,7 @@ let Scripts = function () {
         regExGlobalOld = /_global$/,
         regExGlobalNew = /script\.js\.global\./;
 
-    let ids = {}, fns = {}, objs = {}, scripts, self = this;
+    let ids = {}, fns = {}, objs = {}, scripts = [], self = this;
 
     this.globalScript = '';
 
@@ -559,15 +559,15 @@ let watcher = {
             }
 
             if (eventType === 'addDir') {
-                console.log('watch: ' + eventType + ' - ' + filename + ' type ignored');
+                adapter.log.debug('watch: ' + eventType + ' - ' + filename + ' type ignored');
                 return;
             }
             //jetbrians temp filename: \global\Global_global.js___jb_tmp___
             if (!filename || !/\.js$|\.json$/.test(filename)) {
-                console.log('watch: ' + eventType + ' - ' + filename + ' ignored');
+                adapter.log.debug('watch: ' + eventType + ' - ' + filename + ' ignored');
                 return;
             }
-            console.log ('watch: ' + eventType + ' - ' + filename);
+            adapter.log.debug('watch: ' + eventType + ' - ' + filename);
 
             let fullfn = filename;
             if (filename.indexOf(adapter.config.rootDir) === 0) filename = filename.substring(adapter.config.rootDir.length);
@@ -578,7 +578,7 @@ let watcher = {
             } else {
                 let obj = scripts.fn2obj(filename);
                 if (obj && eventType === 'add') {
-                    console.log('watch: ' + eventType + ' - ' + filename + ' ignored, because already exists');
+                    adapter.log.debug('watch: ' + eventType + ' - ' + filename + ' ignored, because already exists');
                     return;
                 }
                 let cmdRes = file.source.match(/^[\/\s]*!!([\S]*)/);

--- a/js2fs.js
+++ b/js2fs.js
@@ -624,7 +624,7 @@ let watcher = {
             }
         });
     },
-    restart: this.run,
+    restart: this.run
 };
 
 

--- a/js2fs.js
+++ b/js2fs.js
@@ -305,6 +305,7 @@ let Scripts = function () {
     let getmtime = function (fn, common) {
         let stat = soef.lstatSync(adapter.config.rootDir.fullFn(fn));
         if (stat && stat.mtime) {
+            adapter.log.debug('get mtime: ' + stat.mtime);
             common.mtime = stat.mtime;
         }
     };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "child_process": "^1.0.2",
     "path": "^0.12.7",
-    "soef": "^0.4.4"
+    "soef": "^0.4.4",
+    "chokidar": "^1.7.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -454,6 +454,7 @@ function startAdapter(objects, states, callback) {
     if (adapterStarted) {
         console.log('Adapter already started ...');
         if (callback) callback(objects, states);
+        return;
     }
     adapterStarted = true;
     console.log('startAdapter...');

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -450,6 +450,11 @@ function setupController(cb) {
 }
 
 function startAdapter(objects, states, callback) {
+    if (adapterStarted) {
+        console.log('Adapter already started ...');
+        if (callback) callback(objects, states);
+    }
+    adapterStarted = true;
     console.log('startAdapter...');
     if (fs.existsSync(rootDir + 'tmp/node_modules/' + pkg.name + '/' + pkg.main)) {
         try {
@@ -485,6 +490,7 @@ function startController(isStartAdapter, onObjectChange, onStateChange, callback
         callback  = onObjectChange;
         onObjectChange = undefined;
     }
+    var adapterStarted = false;
 
     if (pid) {
         console.error('Controller is already started!');

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -484,6 +484,8 @@ function startAdapter(objects, states, callback) {
 
 function startController(isStartAdapter, onObjectChange, onStateChange, callback) {
     if (typeof isStartAdapter === 'function') {
+        callback = onStateChange;
+        onStateChange = onObjectChange
         onObjectChange = isStartAdapter;
         isStartAdapter = true;
     }

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -11,6 +11,7 @@ pkg.main = pkg.main || 'main.js';
 
 var adapterName = path.normalize(rootDir).replace(/\\/g, '/').split('/');
 adapterName = adapterName[adapterName.length - 2];
+var adapterStarted = false;
 
 function getAppName() {
     var parts = __dirname.replace(/\\/g, '/').split('/');
@@ -490,7 +491,6 @@ function startController(isStartAdapter, onObjectChange, onStateChange, callback
         callback  = onObjectChange;
         onObjectChange = undefined;
     }
-    var adapterStarted = false;
 
     if (pid) {
         console.error('Controller is already started!');

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -251,7 +251,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             if (id !== 'script.js.tests.TestScript2') return;
 
             expect(obj.common.source).to.be.equal(scriptContent);
-            expect(new Date().getUnixTime()-obj.common.mtime).to.be.less(10);
+            expect((new Date().getTime()/1000)-obj.common.mtime).to.be.less(10);
             onObjectChanged = null;
             done();
         };

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -84,7 +84,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         setup.setupController(function () {
             var config = setup.getAdapterConfig();
             // enable adapter
-            config.common.enabled  = true;
+            config.common.enabled  = false;
             config.common.loglevel = 'debug';
 
             fs.mkdirSync(scriptDir);
@@ -216,7 +216,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             done();
         };
 
-        fs.writeFileSync(scriptFileTest1,scriptContent);
+        fs.writeFileSync(scriptFileTest2,scriptContent);
     });
 
     after('Test ' + adapterShortName + ' adapter: Stop js-controller', function (done) {

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -84,7 +84,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         setup.setupController(function () {
             var config = setup.getAdapterConfig();
             // enable adapter
-            config.common.enabled  = false;
+            config.common.enabled  = true;
             config.common.loglevel = 'debug';
 
             fs.mkdirSync(scriptDir);
@@ -100,7 +100,6 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             function (_objects, _states) {
                 objects = _objects;
                 states  = _states;
-                states.subscribe('*');
                 var script = {
                     "common": {
                         "name":         "Global Script",

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -128,9 +128,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                     };
                     objects.setObject(script._id, script, function (err) {
                         expect(err).to.be.not.ok;
-                        setup.startAdapter(objects, states, function () {
-                            _done();
-                        });
+                        _done();
                     });
                 });
             });
@@ -140,36 +138,40 @@ describe('Test ' + adapterShortName + ' adapter', function() {
 /*
     ENABLE THIS WHEN ADAPTER RUNS IN DEAMON MODE TO CHECK THAT IT HAS STARTED SUCCESSFULLY
 */
-    it('Test ' + adapterShortName + ' adapter: Check if adapter started', function (done) {
+    it('Test ' + adapterShortName + ' adapter: start adapter and Check if adapter started', function (done) {
         this.timeout(60000);
         var changedObjects = {};
+        var connectionChecked = false;
         onObjectChanged = function (id, obj) {
             console.log('Go Object-Modification for ' + id);
             if (id.substring(0,10) === 'script.js.') {
                 changedObjects[id] = true;
-                if (Object.keys(changedObjects).length === 2) {
+                if (Object.keys(changedObjects).length === 2 && connectionChecked) {
                     onObjectChanged = null;
                     done();
                 }
             }
         };
 
-        checkConnectionOfAdapter(function (res) {
-            if (res) console.log(res);
-            expect(res).not.to.be.equal('Cannot check connection');
-            objects.setObject('system.adapter.test.0', {
-                    common: {
+        setup.startAdapter(objects, states, function () {
+            checkConnectionOfAdapter(function (res) {
+                if (res) console.log(res);
+                expect(res).not.to.be.equal('Cannot check connection');
+                objects.setObject('system.adapter.test.0', {
+                        common: {
 
+                        },
+                        type: 'instance'
                     },
-                    type: 'instance'
-                },
-                function () {
-                    states.subscribeMessage('system.adapter.test.0');
-                    if (Object.keys(changedObjects).length === 2) {
-                        onObjectChanged = null;
-                        done();
-                    }
-                });
+                    function () {
+                        states.subscribeMessage('system.adapter.test.0');
+                        connectionChecked = true;
+                        if (Object.keys(changedObjects).length === 2 && connectionChecked) {
+                            onObjectChanged = null;
+                            done();
+                        }
+                    });
+            });
         });
     });
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -102,6 +102,8 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             function (_objects, _states) {
                 objects = _objects;
                 states  = _states;
+                states.subscribe("*");
+                objects.subscribe("*");
                 var script = {
                     "common": {
                         "name":         "Global Script",

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -175,10 +175,10 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         else {
                             setTimeout(function() {
                                 objects.getObject('script.js.global.TestGlobal', function(err, obj) {
-                                    expect(err).to.be.ok;
+                                    expect(err).to.be.null;
                                     expect(obj.mtime).not.to.be.undefined;
                                     objects.getObject('script.js.tests.TestScript1', function(err, obj) {
-                                        expect(err).to.be.ok;
+                                        expect(err).to.be.null;
                                         expect(obj.mtime).not.to.be.undefined;
                                         expect(connectionChecked).to.be.true;
                                         onObjectChanged = null;
@@ -223,7 +223,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             fs.writeFileSync(scriptFileTest1,scriptContent);
             setTimeout(function() {
                 objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
-                    expect(err).to.be.ok;
+                    expect(err).to.be.null;
                     expect(obj2.mtime).not.to.be.undefined;
                     expect(obj2.mtime).not.to.be.equal(obj.mtime);
                     onObjectChanged = null;
@@ -252,7 +252,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         fs.writeFileSync(scriptFileTest2,scriptContent);
         setTimeout(function() {
             objects.getObject('script.js.tests.TestScript2', function(err, obj) {
-                expect(err).to.be.ok;
+                expect(err).to.be.null;
                 expect(obj.mtime).not.to.be.undefined;
                 onObjectChanged = null;
                 done();

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -144,8 +144,8 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         this.timeout(60000);
         var changedObjects = {};
         onObjectChanged = function (id, obj) {
+            console.log('Go Object-Modification for ' + id);
             if (id.substring(0,10) === 'script.js.') {
-                console.log('Go Object-Modification for ' + id);
                 changedObjects[id] = true;
                 if (Object.keys(changedObjects).length === 2) {
                     onObjectChanged = null;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -223,6 +223,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             expect(err).to.be.null;
             expect(obj.common.mtime).not.to.be.undefined;
 
+            console.log('CHANGE Local File TestScript1');
             fs.writeFileSync(scriptFileTest1,scriptContent);
             setTimeout(function() {
                 objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
@@ -253,6 +254,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             done();
         };
 
+        console.log('CREATE Local File TestScript2');
         fs.writeFileSync(scriptFileTest2,scriptContent);
         setTimeout(function() {
             objects.getObject('script.js.tests.TestScript2', function(err, obj) {

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -229,6 +229,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                 objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
                     console.log(JSON.stringify(obj2));
                     expect(err).to.be.null;
+                    expect(obj2.common.source).to.be.equal(scriptContent);
                     expect(obj2.common.mtime).not.to.be.undefined;
                     expect(obj2.common.mtime).not.to.be.equal(obj.common.mtime);
                     onObjectChanged = null;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -175,11 +175,13 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         else {
                             setTimeout(function() {
                                 objects.getObject('script.js.global.TestGlobal', function(err, obj) {
+                                    console.log(JSON.stringofy(obj));
                                     expect(err).to.be.null;
-                                    expect(obj.mtime).not.to.be.undefined;
+                                    expect(obj.common.mtime).not.to.be.undefined;
                                     objects.getObject('script.js.tests.TestScript1', function(err, obj) {
+                                        console.log(JSON.stringofy(obj));
                                         expect(err).to.be.null;
-                                        expect(obj.mtime).not.to.be.undefined;
+                                        expect(obj.common.mtime).not.to.be.undefined;
                                         expect(connectionChecked).to.be.true;
                                         onObjectChanged = null;
                                         done();
@@ -217,15 +219,17 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         };
 
         objects.getObject('script.js.tests.TestScript1', function(err, obj) {
-            expect(err).to.be.ok;
-            expect(obj.mtime).not.to.be.undefined;
+            console.log(JSON.stringofy(obj));
+            expect(err).to.be.null;
+            expect(obj.common.mtime).not.to.be.undefined;
 
             fs.writeFileSync(scriptFileTest1,scriptContent);
             setTimeout(function() {
                 objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
+                    console.log(JSON.stringofy(obj2));
                     expect(err).to.be.null;
-                    expect(obj2.mtime).not.to.be.undefined;
-                    expect(obj2.mtime).not.to.be.equal(obj.mtime);
+                    expect(obj2.common.mtime).not.to.be.undefined;
+                    expect(obj2.common.mtime).not.to.be.equal(obj.common.mtime);
                     onObjectChanged = null;
                     done();
                 });
@@ -252,8 +256,9 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         fs.writeFileSync(scriptFileTest2,scriptContent);
         setTimeout(function() {
             objects.getObject('script.js.tests.TestScript2', function(err, obj) {
+                console.log(JSON.stringofy(obj));
                 expect(err).to.be.null;
-                expect(obj.mtime).not.to.be.undefined;
+                expect(obj.common.mtime).not.to.be.undefined;
                 onObjectChanged = null;
                 done();
             });

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -170,7 +170,11 @@ describe('Test ' + adapterShortName + ' adapter', function() {
 
     it('Test ' + adapterShortName + ' adapter: Check that file got created', function (done) {
         this.timeout(60000);
-        if (fs.existsSync(path.join(scriptDir,'tests','TestScript1') + '.js')) done();
+        var scriptFileTest1 = path.join(scriptDir,'tests','TestScript1') + '.js';
+        expect(fs.existsSync(path.join(scriptDir,'js2fs-settings') + '.json')).to.be.true;
+        expect(fs.existsSync(scriptFileTest1)).to.be.true;
+        expect(fs.readFileSync(scriptFileTest1)).to.be.equal("console.log('Test Script 1');");
+        done();
     });
 
     after('Test ' + adapterShortName + ' adapter: Stop js-controller', function (done) {

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -175,11 +175,11 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         else {
                             setTimeout(function() {
                                 objects.getObject('script.js.global.TestGlobal', function(err, obj) {
-                                    console.log(JSON.stringofy(obj));
+                                    console.log(JSON.stringify(obj));
                                     expect(err).to.be.null;
                                     expect(obj.common.mtime).not.to.be.undefined;
                                     objects.getObject('script.js.tests.TestScript1', function(err, obj) {
-                                        console.log(JSON.stringofy(obj));
+                                        console.log(JSON.stringify(obj));
                                         expect(err).to.be.null;
                                         expect(obj.common.mtime).not.to.be.undefined;
                                         expect(connectionChecked).to.be.true;
@@ -219,14 +219,14 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         };
 
         objects.getObject('script.js.tests.TestScript1', function(err, obj) {
-            console.log(JSON.stringofy(obj));
+            console.log(JSON.stringify(obj));
             expect(err).to.be.null;
             expect(obj.common.mtime).not.to.be.undefined;
 
             fs.writeFileSync(scriptFileTest1,scriptContent);
             setTimeout(function() {
                 objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
-                    console.log(JSON.stringofy(obj2));
+                    console.log(JSON.stringify(obj2));
                     expect(err).to.be.null;
                     expect(obj2.common.mtime).not.to.be.undefined;
                     expect(obj2.common.mtime).not.to.be.equal(obj.common.mtime);
@@ -256,7 +256,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         fs.writeFileSync(scriptFileTest2,scriptContent);
         setTimeout(function() {
             objects.getObject('script.js.tests.TestScript2', function(err, obj) {
-                console.log(JSON.stringofy(obj));
+                console.log(JSON.stringify(obj));
                 expect(err).to.be.null;
                 expect(obj.common.mtime).not.to.be.undefined;
                 onObjectChanged = null;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -232,6 +232,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                     expect(obj2.common.source).to.be.equal(scriptContent);
                     expect(obj2.common.mtime).not.to.be.undefined;
                     expect(obj2.common.mtime).not.to.be.equal(obj.common.mtime);
+                    expect(new Date().getUnixTime()-obj.common.mtime).to.be.less(10);
                     onObjectChanged = null;
                     done();
                 });

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -93,8 +93,10 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             setup.setAdapterConfig(config.common, config.native);
 
             setup.startController(false, function (id, obj) {
+                    console.log('CHANGE OBJECT ' + id);
                     if (onObjectChanged) onObjectChanged(id, obj);
                 }, function (id, state) {
+                    console.log('CHANGE STATE ' + id);
                     if (onStateChanged) onStateChanged(id, state);
             },
             function (_objects, _states) {
@@ -180,7 +182,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         var scriptFileTest1 = path.join(scriptDir,'tests','TestScript1') + '.js';
         expect(fs.existsSync(path.join(scriptDir,'js2fs-settings') + '.json')).to.be.true;
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
-        expect(fs.readFileSync(scriptFileTest1)).to.be.equal("console.log('Test Script 1');");
+        expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('Test Script 1');");
         done();
     });
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -183,7 +183,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         expect(fs.existsSync(path.join(scriptDir,'js2fs-settings') + '.json')).to.be.true;
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('Test Script 1');");
-        done();
+        setTimeout(done, 2000);
     });
 
     it('Test ' + adapterShortName + ' adapter: update TestScript 1', function (done) {
@@ -201,7 +201,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             expect(((new Date().getTime()/1000)-obj2.common.mtime)<10).to.be.true;
             expect(obj2.common.mtime).not.to.be.equal(initObj.common.mtime);
             onObjectChanged = null;
-            done();
+            setTimeout(done, 2000);
         };
 
         objects.getObject('script.js.tests.TestScript1', function(err, obj) {
@@ -227,7 +227,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             expect(obj.common.source).to.be.equal(scriptContent);
             expect(obj.common.mtime).not.to.be.undefined;
             onObjectChanged = null;
-            done();
+            setTimeout(done, 2000);
         };
 
         console.log('CREATE Local File TestScript2');

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -154,7 +154,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                 }
             }
         };
-
+        console.log('START NOW');
         setup.startAdapter(objects, states, function () {
             checkConnectionOfAdapter(function (res) {
                 if (res) console.log(res);
@@ -171,6 +171,21 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         if (Object.keys(changedObjects).length === 2 && connectionChecked) {
                             onObjectChanged = null;
                             done();
+                        }
+                        else {
+                            setTimeout(function() {
+                                objects.getObject('script.js.global.TestGlobal', function(err, obj) {
+                                    expect(err).to.be.ok;
+                                    expect(obj.mtime).not.to.be.undefined;
+                                    objects.getObject('script.js.tests.TestScript1', function(err, obj) {
+                                        expect(err).to.be.ok;
+                                        expect(obj.mtime).not.to.be.undefined;
+                                        expect(connectionChecked).to.be.true;
+                                        onObjectChanged = null;
+                                        done();
+                                    });
+                                });
+                            }, 5000);
                         }
                     });
             });
@@ -201,7 +216,22 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             done();
         };
 
-        fs.writeFileSync(scriptFileTest1,scriptContent);
+        objects.getObject('script.js.tests.TestScript1', function(err, obj) {
+            expect(err).to.be.ok;
+            expect(obj.mtime).not.to.be.undefined;
+
+            fs.writeFileSync(scriptFileTest1,scriptContent);
+            setTimeout(function() {
+                objects.getObject('script.js.tests.TestScript1', function(err, obj2) {
+                    expect(err).to.be.ok;
+                    expect(obj2.mtime).not.to.be.undefined;
+                    expect(obj2.mtime).not.to.be.equal(obj.mtime);
+                    onObjectChanged = null;
+                    done();
+                });
+            }, 5000);
+        });
+
     });
 
     it('Test ' + adapterShortName + ' adapter: create TestScript 2', function (done) {
@@ -220,6 +250,14 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         };
 
         fs.writeFileSync(scriptFileTest2,scriptContent);
+        setTimeout(function() {
+            objects.getObject('script.js.tests.TestScript2', function(err, obj) {
+                expect(err).to.be.ok;
+                expect(obj.mtime).not.to.be.undefined;
+                onObjectChanged = null;
+                done();
+            });
+        }, 5000);
     });
 
     after('Test ' + adapterShortName + ' adapter: Stop js-controller', function (done) {


### PR DESCRIPTION
Hi Soef,

I needed to change more then I initially wanted (and also that's why several commits, simply sqash them :-) , but here is the changelog:
- update testing files and testing
- add adapter specific testing (initial script-to-file, check file-creation, changing files and check object update, add file and check object), both Travis-CI (https://travis-ci.org/Apollon77/iobroker.js2fs/builds/267886733) and Appveyor (https://ci.appveyor.com/project/Apollon77/iobroker-js2fs) are green for Linux, MacOS and Windows now!
- update code to not only work with windows paths (fixes #2)
- replace fs.watch by chokidar library to allow recursive watch also on Linux/Mac (not working with fs.watch)

I hope I have not damaged anything, especially with debugging because I have not tested this (but also not really touched it). There were still some things in it where I still do not really understand what/why you do several things ... but testings show that it works for the normal cases.

What you think?

Ingo F