### PR TITLE
allow to chenge chokidar fs.watchFile to fs.watch

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -34,6 +34,7 @@
         if (settings.useGlobalScriptAsPrefix === undefined) settings.useGlobalScriptAsPrefix = true;
         if (settings.restartScript === undefined) settings.restartScript = true;
         if (settings.disableWrite === undefined) settings.disableWrite = false;
+        if (settings.usePolling === undefined) settings.usePolling = false;
         if (settings.ioBrokerRootdir === undefined) settings.ioBrokerRootdir = '';
         if (settings.basicSync === undefined) settings.basicSync = false;
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -184,6 +184,7 @@
             <tr><td class="translate">useGlobalScriptAsPrefix</td><td width=5></td><td><input type="checkbox" id="useGlobalScriptAsPrefix" class="value" size=20></td></tr>
             <tr><td class="translate">restartScript</td><td width=5></td><td><input type="checkbox" id="restartScript" class="value" size=20></td></tr>
             <tr><td class="translate">disableWrite</td><td width=5></td><td><input type="checkbox" id="disableWrite" class="value" size=20></td></tr>
+            <tr><td class="translate">usePolling</td><td width=5></td><td><input type="checkbox" id="usePolling" class="value" size=20></td></tr>
         </table>
         <table>
             <h1 class="translate">log</h1>

--- a/admin/words.js
+++ b/admin/words.js
@@ -49,6 +49,10 @@ systemDictionary = {
         "en": "Disable write (save)",
         "de": "Schreiben (Speichern) unterbinden"
     },
+    "usePolling": {
+        "en": "Use Polling instead of fs.watch - should be only checked for non-standard situations",
+        "de": "Benutze polling anstelle der Standard Methode. Sollte nur in sonderfällen aktiviert werden."
+    },    
     "options": {
         "en": "Options",
         "de": "Optionen"

--- a/admin/words.js
+++ b/admin/words.js
@@ -50,8 +50,8 @@ systemDictionary = {
         "de": "Schreiben (Speichern) unterbinden"
     },
     "usePolling": {
-        "en": "Use Polling instead of fs.watch - should be only checked for non-standard situations",
-        "de": "Benutze polling anstelle der Standard Methode. Sollte nur in sonderfällen aktiviert werden."
+        "en": "Constant polling of file states",
+        "de": "ständiges abfragen der Dateizustände"
     },    
     "options": {
         "en": "Options",

--- a/io-package.json
+++ b/io-package.json
@@ -120,7 +120,8 @@
         "rootDir": "",
         "useGlobalScriptAsPrefix": true,
         "restartScript": true,
-        "disableWrite": false
+        "disableWrite": false,
+        "usePolling": false
     },
     "objects": []
 }


### PR DESCRIPTION
I have some Problems with Network drives. where the Adapter stops working.
The chokidar library has a option for the file system watcher "usePolling" which is on default: false


The description to this option is:
It is typically necessary to set this to true to successfully watch files over a network, and it may be necessary to successfully watch files in other non-standard situations.

If I set this opthin to true my problems seems to go away, so I have moved this option to the adapter settings.