### PR TITLE
0.1.6: Use oficial Object timestamps, Update testing and base files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 os:
   - linux
   - osx
+  - windows
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
   - '10'
@@ -11,13 +11,13 @@ before_script:
   - export NPMVERSION=$(echo "$($(which npm) -v)"|cut -c1)
   - 'if [[ $NPMVERSION == 5 ]]; then npm install -g npm@5; fi'
   - npm -v
-  - npm install winston@2.3.1
+  - npm install winston@3.2.1
   - 'npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production'
 env:
-  - CXX=g++-4.8
+  - CXX=g++-4.9
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+      - g++-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,21 @@ os:
   - osx
 language: node_js
 node_js:
-  - "4"
-  - "6"
-  - "8"
+  - '4'
+  - '6'
+  - '8'
+  - '10'
 before_script:
+  - export NPMVERSION=$(echo "$($(which npm) -v)"|cut -c1)
+  - 'if [[ $NPMVERSION == 5 ]]; then npm install -g npm@5; fi'
+  - npm -v
   - npm install winston@2.3.1
-  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+  - 'npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production'
 env:
   - CXX=g++-4.8
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
+      - g++-4.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 'test-{build}'
 environment:
   matrix:
-    - nodejs_version: '4'
     - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
@@ -15,7 +14,7 @@ install:
   - ps: 'if($NpmVersion -eq 5) { npm install -g npm@5 }'
   - ps: npm --version
   - npm install
-  - npm install winston@2.3.1
+  - npm install winston@3.2.1
   - 'npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production'
 test_script:
   - echo %cd%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,25 @@
 version: 'test-{build}'
-
-# Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: "4"
-    - nodejs_version: "6"
-    - nodejs_version: "8"
-
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+    - nodejs_version: '10'
 platform:
   - x86
   - x64
-
-clone_folder: c:\projects\%APPVEYOR_PROJECT_NAME%
-# Install scripts. (runs after repo cloning)
+clone_folder: 'c:\projects\%APPVEYOR_PROJECT_NAME%'
 install:
-  # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  # install modules
+  - ps: 'Install-Product node $env:nodejs_version $env:platform'
+  - ps: '$NpmVersion = (npm -v).Substring(0,1)'
+  - ps: 'if($NpmVersion -eq 5) { npm install -g npm@5 }'
+  - ps: npm --version
   - npm install
   - npm install winston@2.3.1
-  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
-
-# Post-install test scripts.
+  - 'npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production'
 test_script:
-  # Output useful info for debugging.
   - echo %cd%
   - node --version
   - npm --version
-  # run tests
   - npm test
-
-# Don't actually build.
-build: off
+build: 'off'

--- a/io-package.json
+++ b/io-package.json
@@ -5,6 +5,7 @@
         "title": "Javascript to file",
         "desc": "Javascript to file",
         "platform": "Javascript/Node.js",
+        "license": "MIT",
         "news": {
             "0.1.6": {
                 "en": "Fix Handling of Non-JavaScript types (Apollon77)",

--- a/io-package.json
+++ b/io-package.json
@@ -1,11 +1,15 @@
 {
     "common": {
         "name": "js2fs",
-        "version": "0.1.5",
+        "version": "0.1.6",
         "title": "Javascript to file",
         "desc": "Javascript to file",
         "platform": "Javascript/Node.js",
         "news": {
+            "0.1.6": {
+                "en": "Fix Handling of Non-JavaScript types (Apollon77)",
+                "de": "Behandlung von Nicht-JavaScript Typen korrigiert (Apollon77)"
+            },
             "0.1.5": {
                 "en": "Option to poll file states added  (Apollon77)",
                 "de": "Option Dateizustände zu pollen hinzugefügt (Apollon77)"

--- a/js2fs.js
+++ b/js2fs.js
@@ -348,6 +348,7 @@ let Scripts = function () {
         if (path.endsWith('.ts')) engineType = 'TypeScript/ts';
         if (path.endsWith('.coffee')) engineType = 'Coffeescript/coffee';
         if (path.endsWith('.blockly')) engineType = 'Blockly';
+        adapter.log.debug('create script ' + name + ' for Type ' + engineType);
 
         let obj = {
             type: 'script',
@@ -539,6 +540,7 @@ files = new (Files = class extends Array {
                 fs.closeSync(fd);
             }
         } catch (e) {
+            adapter.log.error('Error file "'+fn+'" '+e);
         }
     }
 
@@ -595,7 +597,8 @@ let watcher = {
         this.handle = chokidar.watch(adapter.config.rootDir, {
             ignored: /(^|[\/\\])\../,
             awaitWriteFinish: true,
-            persistent: true
+            persistent: true,
+            usePolling : adapter.config.usePolling, //default: false - set this to true to successfully watch files over a network
         }). on('ready', function () {
             initialScanComplete = true;
         }). on('all', function (eventType, fullfn, details) {
@@ -710,16 +713,22 @@ function start(restartCount) {
                     return setTimeout(start, 0, (restartCount||0)+1);
                 }
                 scripts.scripts.forEach ((o) => {
-                    if (o.isSettings === 'create') {
-                        o.isSettings = true;
-                        //scripts.update(o); //not necessary, o is a reference and the object is everywhere (e.g. in ids and in fns) the same
-                        adapter.log.debug('Fix isSettings for ' + o.id);
+                    let fullfn;
+                    try {
+                        if (o.isSettings === 'create') {
+                            o.isSettings = true;
+                            //scripts.update(o); //not necessary, o is a reference and the object is everywhere (e.g. in ids and in fns) the same
+                            adapter.log.debug('Fix isSettings for ' + o.id);
+                        }
+                        let fo = fids[o.id];
+                        if (!fo || fo.mtime < o.common.mtime) {
+                            fullfn = adapter.config.rootDir.fullFn (o.fn);
+                            adapter.log.info('Update Script file ' + o.id + ' from ioBroker');
+                            Files.write (fullfn, o.common.source, o.common.mtime);
+                        }
                     }
-                    let fo = fids[o.id];
-                    if (!fo || fo.mtime < o.common.mtime) {
-                        let fullfn = adapter.config.rootDir.fullFn (o.fn);
-                        adapter.log.info('Update Script file ' + o.id + ' from ioBroker');
-                        Files.write (fullfn, o.common.source, o.common.mtime);
+                    catch (e) {
+                        adapter.log.error('Error processing file "' + fullfn + '": ' + e);
                     }
                 });
                 setTimeout(function() {
@@ -732,14 +741,19 @@ function start(restartCount) {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
             let o = files[--i];
             fids[o.id] = o;
-            let obj = scripts.fn2obj (o.fn);
-            //including all script file types, but ignores typescript definition files '.d.ts'
-            if ((!obj || obj.common.mtime < o.mtime) && (o.fullfn.endsWith ('.js') || (!o.fullfn.endsWith ('.d.ts') && o.fullfn.endsWith ('.ts')) || o.fullfn.endsWith ('.coffee') || o.fullfn.endsWith ('.blockly'))) {  // at first only files, no directories
-                if (!obj) rescanRequired = true;
-                let fobj = Files.getObject (o.fullfn);
-                scripts.change (o.fn, fobj.source, fobj.mtime, doIt);
-            } else {
-                setTimeout(doIt, 0);
+            try {
+                let obj = scripts.fn2obj (o.fn);
+                //including all script file types, but ignores typescript definition files '.d.ts'
+                if ((!obj || obj.common.mtime < o.mtime) && (o.fullfn.endsWith ('.js') || (!o.fullfn.endsWith ('.d.ts') && o.fullfn.endsWith ('.ts')) || o.fullfn.endsWith ('.coffee') || o.fullfn.endsWith ('.blockly'))) {  // at first only files, no directories
+                    if (!obj) rescanRequired = true;
+                    let fobj = Files.getObject (o.fullfn);
+                    scripts.change (o.fn, fobj.source, fobj.mtime, doIt);
+                } else {
+                    setTimeout(doIt, 0);
+                }
+            }
+            catch (e) {
+                adapter.log.error('Error processing file "' + o.fullfn + '": ' + e);
             }
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
         })();
@@ -902,6 +916,7 @@ function normalizeConfig(config) {
             adapter.log.info(ar[0]);
 
         } catch (e) {
+            adapter.log.error('Error open file "'+fn+'" '+e);
             let i = e;
         }
     };

--- a/js2fs.js
+++ b/js2fs.js
@@ -437,8 +437,8 @@ let Scripts = function () {
                 else o.ts = mtime*1000;
             obj.common.source = source;
             obj.ts = o.ts;
-            delete obj.mtime;
-            delete o.common.mtime;
+            obj.mtime = 0;
+            o.common.mtime = 0;
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;

--- a/js2fs.js
+++ b/js2fs.js
@@ -437,6 +437,7 @@ let Scripts = function () {
                 else o.ts = mtime*1000;
             obj.common.source = source;
             obj.ts = mtime*1000;
+            obj.mtime = 0;
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;

--- a/js2fs.js
+++ b/js2fs.js
@@ -222,7 +222,7 @@ let Scripts = function () {
         fns = {};
         objs = {};
         scripts = [];
-        let settingsFound, now = new Date().getUnixTime();
+        let settingsFound, now = new Date().getTime();
         this.globalScript = '';
 
         adapter.objects.getObjectList({
@@ -241,14 +241,18 @@ let Scripts = function () {
                     id: o._id,
                 };
                 let mtime;
-                if (!o.from) { // js-controller < 1.2.0
+                if (!o.from && !o.ts) { // js-controller < 1.2.0
                     if (typeof oo.common.mtime === 'string') {
-                        oo.common.mtime = new Date(oo.common.mtime).getUnixTime();
-                        soef.modifyObject(oo.id, {common: { mtime: oo.common.mtime }});
+                        oo.ts = o.ts = new Date(oo.common.mtime).getTime();
+                        soef.modifyObject(oo.id, {ts: o.ts, common: { mtime: 0 }});
                     }
-                    if (!oo.common.mtime || oo.common.mtime > now) {
-                        oo.common.mtime = now;
-                        soef.modifyObject(oo.id, {common: { mtime: now }});
+                    else if (!oo.common.mtime) {
+                        oo.ts = o.ts = now;
+                        soef.modifyObject(oo.id, {ts: o.ts});
+                    }
+                    else if (oo.common.mtime > now) {
+                        oo.ts = o.ts = now;
+                        soef.modifyObject(oo.id, {ts: o.ts, common: { mtime: 0 }});
                     }
                 }
                 else {
@@ -320,12 +324,13 @@ let Scripts = function () {
         });
     };
 
-    let getmtime = function (fn, common) {
+    let getmtime = function (fn) {
         let stat = soef.lstatSync(adapter.config.rootDir.fullFn(fn));
         if (stat && stat.mtime) {
-            common.mtime = stat.mtime.getUnixTime();
+            return stat.mtime.getUnixTime();
             //adapter.log.debug('getmtime: ' + stat.mtime.toJSON());
         }
+        return 0;
     };
 
     this.removeGlobalScript = function (source) {
@@ -359,13 +364,13 @@ let Scripts = function () {
                 verbose: false,
                 name: name,
                 enabled: false,
-                source: self.removeGlobalScript(data),
-                mtime: mtime
+                source: self.removeGlobalScript(data)
             },
             native: {}
         };
 
-        if (!mtime) getmtime(path, obj.common);
+        if (!mtime) obj.ts = getmtime(path) * 1000;
+            else obj.ts = mtime * 1000;
         adapter.log.debug('scripts.create: New Object: ' + id);
         adapter.log.info('New Script file ' + id + ' found, also create in ioBroker');
         //soef.lastIdToModify = id;
@@ -394,10 +399,10 @@ let Scripts = function () {
             return this.create (fn, source, mtime, callback);
         }
 
-        if (!obj.common || (obj.common.source === source && obj.common.mtime === mtime)) return callback && callback();
+        if (!obj.common || (obj.common.source === source && obj.ts === mtime*1000)) return callback && callback();
 
         obj.common.source = source;
-        obj.common.mtime = mtime;
+        obj.ts = mtime*1000;
 
         if (!obj.isGlobal || !adapter.config.useGlobalScriptAsPrefix) {
             source = this.removeGlobalScript (source);
@@ -428,10 +433,10 @@ let Scripts = function () {
         adapter.log.info('Script file ' + id + ' changed, also update in ioBroker');
         soef.modifyObject(id, function (o) {
             o.common.source = source;
-            o.common.mtime = mtime;
+            if (!o.ts) o.ts = getmtime(fn) * 1000;
+                else o.ts = mtime*1000;
             obj.common.source = source;
-            obj.common.mtime = mtime;
-            if (!mtime) getmtime (fn, o.common);
+            obj.ts = mtime*1000;
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;
@@ -504,7 +509,7 @@ files = new (Files = class extends Array {
                 //id: Files.fn2id (fullfn.withoutRoot ()),
                 fullfn: fullfn,
                 fn: fullfn.withoutRoot(), // substr (dir.length),
-                mtime: stat.mtime.getUnixTime (),
+                ts: stat.mtime.getUnixTime ()*1000,
                 size: stat.size,
             };
             let o = scripts.fn2obj(oo.fn);
@@ -549,7 +554,7 @@ files = new (Files = class extends Array {
         let stat = soef.lstatSync(fn);
         obj.source = soef.readFileSync(fn);
         if (obj.source) obj.source = obj.source.toString();
-        obj.mtime = stat.mtime.getUnixTime();
+        obj.ts = stat.mtime.getUnixTime()*1000;
         adapter.log.debug('Files.getObject: mtime=' + stat.mtime.toJSON());
         return obj;
     }
@@ -683,7 +688,8 @@ let watcher = {
                     adapter.getForeignObject(obj.id, function (err, o) {
                         if (err || !o) return;
                         obj.common = o.common;
-                        Files.write(filename.fullFn(), o.common.source, o.common.mtime);
+                        obj.ts = o.ts;
+                        Files.write(filename.fullFn(), o.common.source, new Date(o.ts).getUnixTime());
                     });
                     break;
 
@@ -721,10 +727,10 @@ function start(restartCount) {
                             adapter.log.debug('Fix isSettings for ' + o.id);
                         }
                         let fo = fids[o.id];
-                        if (!fo || fo.mtime < o.common.mtime) {
+                        if (!fo || fo.ts < o.ts) {
                             fullfn = adapter.config.rootDir.fullFn (o.fn);
                             adapter.log.info('Update Script file ' + o.id + ' from ioBroker');
-                            Files.write (fullfn, o.common.source, o.common.mtime);
+                            Files.write (fullfn, o.common.source, new Date(o.ts).getUnixTime());
                         }
                     }
                     catch (e) {
@@ -744,10 +750,10 @@ function start(restartCount) {
             try {
                 let obj = scripts.fn2obj (o.fn);
                 //including all script file types, but ignores typescript definition files '.d.ts'
-                if ((!obj || obj.common.mtime < o.mtime) && (o.fullfn.endsWith ('.js') || (!o.fullfn.endsWith ('.d.ts') && o.fullfn.endsWith ('.ts')) || o.fullfn.endsWith ('.coffee') || o.fullfn.endsWith ('.blockly'))) {  // at first only files, no directories
+                if ((!obj || obj.ts < o.ts) && (o.fullfn.endsWith ('.js') || (!o.fullfn.endsWith ('.d.ts') && o.fullfn.endsWith ('.ts')) || o.fullfn.endsWith ('.coffee') || o.fullfn.endsWith ('.blockly'))) {  // at first only files, no directories
                     if (!obj) rescanRequired = true;
                     let fobj = Files.getObject (o.fullfn);
-                    scripts.change (o.fn, fobj.source, fobj.mtime, doIt);
+                    scripts.change (o.fn, fobj.source, new Date(fobj.ts).getUnixTime(), doIt);
                 } else {
                     setTimeout(doIt, 0);
                 }

--- a/js2fs.js
+++ b/js2fs.js
@@ -437,8 +437,8 @@ let Scripts = function () {
                 else o.ts = mtime*1000;
             obj.common.source = source;
             obj.ts = o.ts;
-            obj.mtime = 0;
-            o.common.mtime = 0;
+            if (obj.mtime) obj.mtime = 0;
+            if (o.common.mtime) o.common.mtime = 0;
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;

--- a/js2fs.js
+++ b/js2fs.js
@@ -436,8 +436,9 @@ let Scripts = function () {
             if (!o.ts) o.ts = getmtime(fn) * 1000;
                 else o.ts = mtime*1000;
             obj.common.source = source;
-            obj.ts = mtime*1000;
-            obj.mtime = 0;
+            obj.ts = o.ts;
+            delete obj.mtime;
+            delete o.common.mtime;
             if (adapter.config.restartScript) {
                 oldEnabled = o.common.enabled;
                 o.common.enabled = false;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,39 +1,47 @@
-var controllerDir;
-var appName;
+'use strict';
 
-function getAppName() {
-    var parts = __dirname.replace(/\\/g, '/').split('/');
+const fs = require('fs');
+const path = require('path');
+
+let controllerDir;
+let appName;
+
+/**
+ * returns application name
+ *
+ * The name of the application can be different and this function finds it out.
+ *
+ * @returns {string}
+ */
+ function getAppName() {
+    const parts = __dirname.replace(/\\/g, '/').split('/');
     return parts[parts.length - 2].split('.')[0];
 }
 
-// Get js-controller directory to load libs
+/**
+ * looks for js-controller home folder
+ *
+ * @param {boolean} isInstall
+ * @returns {string}
+ */
 function getControllerDir(isInstall) {
-    var fs = require('fs');
     // Find the js-controller location
-    var controllerDir = __dirname.replace(/\\/g, '/');
-    controllerDir = controllerDir.split('/');
-    if (controllerDir[controllerDir.length - 3] === 'adapter') {
-        controllerDir.splice(controllerDir.length - 3, 3);
-        controllerDir = controllerDir.join('/');
-    } else if (controllerDir[controllerDir.length - 3] === 'node_modules') {
-        controllerDir.splice(controllerDir.length - 3, 3);
-        controllerDir = controllerDir.join('/');
-        if (fs.existsSync(controllerDir + '/node_modules/' + appName + '.js-controller')) {
-            controllerDir += '/node_modules/' + appName + '.js-controller';
-        } else if (fs.existsSync(controllerDir + '/node_modules/' + appName.toLowerCase() + '.js-controller')) {
-            controllerDir += '/node_modules/' + appName.toLowerCase() + '.js-controller';
-        } else if (!fs.existsSync(controllerDir + '/controller.js')) {
-            if (!isInstall) {
-                console.log('Cannot find js-controller');
-                process.exit(10);
-            } else {
-                process.exit();
+    const possibilities = [
+        'iobroker.js-controller',
+        'ioBroker.js-controller',
+    ];
+    /** @type {string} */
+    let controllerPath;
+    for (const pkg of possibilities) {
+        try {
+            const possiblePath = require.resolve(pkg);
+            if (fs.existsSync(possiblePath)) {
+                controllerPath = possiblePath;
+                break;
             }
-        }
-    } else if (fs.existsSync(__dirname + '/../../node_modules/' + appName.toLowerCase() + '.js-controller')) {
-        controllerDir.splice(controllerDir.length - 2, 2);
-        return controllerDir.join('/') + '/node_modules/' + appName.toLowerCase() + '.js-controller';
-    } else {
+        } catch (e) { /* not found */ }
+    }
+    if (controllerPath == null) {
         if (!isInstall) {
             console.log('Cannot find js-controller');
             process.exit(10);
@@ -41,24 +49,35 @@ function getControllerDir(isInstall) {
             process.exit();
         }
     }
-    return controllerDir;
+    // we found the controller
+    return path.dirname(controllerPath);
 }
 
-// Read controller configuration file
-function getConfig() {
-    var fs = require('fs');
-    if (fs.existsSync(controllerDir + '/conf/' + appName + '.json')) {
-        return JSON.parse(fs.readFileSync(controllerDir + '/conf/' + appName + '.json'));
-    } else if (fs.existsSync(controllerDir + '/conf/' + appName.toLowerCase() + '.json')) {
-        return JSON.parse(fs.readFileSync(controllerDir + '/conf/' + appName.toLowerCase() + '.json'));
+/**
+ * reads controller base settings
+ *
+ * @alias getConfig
+ * @returns {object}
+ */
+ function getConfig() {
+    let configPath;
+    if (fs.existsSync(
+        configPath = path.join(controllerDir, 'conf', appName + '.json')
+    )) {
+        return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } else if (fs.existsSync(
+        configPath = path.join(controllerDir, 'conf', + appName.toLowerCase() + '.json')
+    )) {
+        return JSON.parse(fs.readFileSync(configPath, 'utf8'));
     } else {
         throw new Error('Cannot find ' + controllerDir + '/conf/' + appName + '.json');
     }
 }
 appName       = getAppName();
 controllerDir = getControllerDir(typeof process !== 'undefined' && process.argv && process.argv.indexOf('--install') !== -1);
+const adapter = require(path.join(controllerDir, 'lib/adapter.js'));
 
 exports.controllerDir = controllerDir;
 exports.getConfig =     getConfig;
-exports.Adapter =       require(controllerDir + '/lib/adapter.js');
+exports.Adapter =       adapter;
 exports.appName =       appName;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "mocha": "^4.1.0",
-    "chai": "^4.1.2"
+    "chai": "^4.1.2",
+    "@iobroker/adapter-core": "^1.0.3"
   },
   "main": "js2fs.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.js2fs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "ioBroker Javascript to file",
   "author": {
     "name": "soef",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "child_process": "^1.0.2",
     "path": "^0.12.7",
     "soef": "^0.4.4",
-    "chokidar": "^1.7.0"
+    "chokidar": "^1.7.0",
+    "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^4.1.0",
-    "chai": "^4.1.2",
-    "@iobroker/adapter-core": "^1.0.3"
+    "chai": "^4.1.2"
   },
   "main": "js2fs.js",
   "scripts": {

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -311,6 +311,7 @@ function installJsController(cb) {
         } else {
             // check if port 9000 is free, else admin adapter will be added to running instance
             var client = new require('net').Socket();
+            client.on('error', () => {});
             client.connect(9000, '127.0.0.1', function() {
                 console.error('Cannot initiate fisrt run of test, because one instance of application is running on this PC. Stop it and repeat.');
                 process.exit(0);

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -36,7 +36,12 @@ function copyFileSync(source, target) {
         }
     }
 
-    fs.writeFileSync(targetFile, fs.readFileSync(source));
+    try {
+        fs.writeFileSync(targetFile, fs.readFileSync(source));
+    }
+    catch (err) {
+        console.log("file copy error: " +source +" -> " + targetFile + " (error ignored)");
+    }
 }
 
 function copyFolderRecursiveSync(source, target, ignore) {
@@ -61,6 +66,7 @@ function copyFolderRecursiveSync(source, target, ignore) {
             }
 
             var curSource = path.join(source, file);
+            var curTarget = path.join(targetFolder, file);
             if (fs.lstatSync(curSource).isDirectory()) {
                 // ignore grunt files
                 if (file.indexOf('grunt') !== -1) return;
@@ -68,7 +74,7 @@ function copyFolderRecursiveSync(source, target, ignore) {
                 if (file === 'mocha') return;
                 copyFolderRecursiveSync(curSource, targetFolder, ignore);
             } else {
-                copyFileSync(curSource, targetFolder);
+                copyFileSync(curSource, curTarget);
             }
         });
     }
@@ -446,7 +452,23 @@ function setupController(cb) {
             restoreOriginalFiles();
             copyAdapterToController();
         }
-        if (cb) cb();
+        // read system.config object
+        var dataDir = rootDir + 'tmp/' + appName + '-data/';
+
+        var objs;
+        try {
+            objs = fs.readFileSync(dataDir + 'objects.json');
+            objs = JSON.parse(objs);
+        }
+        catch (e) {
+            console.log('ERROR reading/parsing system configuration. Ignore');
+            objs = {'system.config': {}};
+        }
+        if (!objs || !objs['system.config']) {
+            objs = {'system.config': {}};
+        }
+
+        if (cb) cb(objs['system.config']);
     });
 }
 
@@ -538,7 +560,10 @@ function startController(isStartAdapter, onObjectChange, onStateChange, callback
                     if (isStartAdapter) {
                         startAdapter(objects, states, callback);
                     } else {
-                        if (callback) callback(objects, states);
+                        if (callback) {
+                            callback(objects, states);
+                            callback = null;
+                        }
                     }
                 }
             },
@@ -578,7 +603,14 @@ function startController(isStartAdapter, onObjectChange, onStateChange, callback
                 isStatesConnected = true;
                 if (isObjectConnected) {
                     console.log('startController: started!!');
-                    startAdapter(objects, states, callback);
+                    if (isStartAdapter) {
+                        startAdapter(objects, states, callback);
+                    } else {
+                        if (callback) {
+                            callback(objects, states);
+                            callback = null;
+                        }
+                    }
                 }
             },
             change: onStateChange

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -15,6 +15,10 @@ var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.'
 
 var scriptDir = path.join(__dirname, 'myScripts');
 
+Date.prototype.getUnixTime = Date.prototype.getCTime = function () {
+    return toUnixTime(this.getTime());
+};
+
 function fullScriptFn(no, ext) {
     if (!ext) ext = 'js';
     return path.join(scriptDir, 'tests', getTestscriptName(no)) + '.' + ext;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -227,17 +227,23 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         var scriptFileGlobal = path.join(scriptDir, 'global', 'Global Script.js');
         expect(fs.existsSync(scriptFileGlobal)).to.be.true;
         expect(fs.readFileSync(scriptFileGlobal).toString()).to.be.equal("console.log('Global');");
-        expect(new Date(fs.lstatSync(scriptFileGlobal).mtime).getUnixTime()).to.be.equal(1234567890);
+        var stat = fs.lstatSync(scriptFileGlobal);
+        console.log(' STAT: ' + stat.mtime + ' -> ' + new Date(stat.mtime).toString() + '  --- ' + new Date(stat.mtime).getUnixTime())
+        expect(new Date(stat).getUnixTime()).to.be.equal(1234567890);
 
         var scriptFileTest1 = fullScriptFn(1);
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
-        expect(new Date(fs.lstatSync(scriptFileTest1).mtime).getUnixTime()).not.to.be.equal(1234567899);
+        stat = fs.lstatSync(scriptFileTest1);
+        console.log(' STAT: ' + stat.mtime + ' -> ' + new Date(stat.mtime).toString() + '  --- ' + new Date(stat.mtime).getUnixTime())
+        expect(new Date(stat.mtime).getUnixTime()).not.to.be.equal(1234567899);
 
         var scriptFileTest11 = fullScriptFn(11, 'blockly');
         expect(fs.existsSync(scriptFileTest11)).to.be.true;
         expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly');");
-        expect(new Date().getUnixTime() - new Date(fs.lstat(scriptFileTest11).mtime).getUnixTime()).to.be.less(60);
+        stat = fs.lstatSync(scriptFileTest11);
+        console.log(' STAT: ' + stat.mtime + ' -> ' + new Date(stat.mtime).toString() + '  --- ' + new Date(stat.mtime).getUnixTime())
+        expect(new Date().getUnixTime() - new Date(stat.mtime).getUnixTime()).to.be.less(60);
 
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -159,11 +159,11 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                                 "source": "console.log('" + getTestscriptName(1) + "');",
                                 "enabled": true,
                                 "engine": "system.adapter.javascript.0",
-                                "mtime": 1234567899
                             },
                             "type": "script",
                             "_id": "script.js.tests.Test_Script_1",
-                            "native": {}
+                            "native": {},
+                            "ts": 1234567899
                         };
                         objects.setObject(script._id, script, function (err) {
                             expect(err).to.be.not.ok;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -200,7 +200,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             console.log('Got initial Object-Modification for ' + id);
             if (id.substring(0,10) === 'script.js.') {
                 changedObjects[id] = true;
-                if (Object.keys(changedObjects).length >= 3 && connectionChecked) {
+                if (Object.keys(changedObjects).length >= 5 && connectionChecked) {
                     onObjectChanged = null;
                     setTimeout(done, nextDelay);
                 }
@@ -218,7 +218,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         changedObjects['system.adapter.test.0'] = true;
                         states.subscribeMessage('system.adapter.test.0');
                         connectionChecked = true;
-                        if (Object.keys(changedObjects).length >= 3 && connectionChecked) {
+                        if (Object.keys(changedObjects).length >= 5 && connectionChecked) {
                             onObjectChanged = null;
                             setTimeout(done, nextDelay);
                         }

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -15,8 +15,9 @@ var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.'
 
 var scriptDir = path.join(__dirname, 'myScripts');
 
-function fullScriptFn(no) {
-    return path.join(scriptDir, 'tests', getTestscriptName(no)) + '.js';
+function fullScriptFn(no, ext) {
+    if (!ext) ext = 'js';
+    return path.join(scriptDir, 'tests', getTestscriptName(no)) + '.' + ext;
 }
 
 function checkConnectionOfAdapter(cb, counter) {

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -110,7 +110,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             var scriptContent3 = "console.log('" + getTestscriptName(3) + " - LOCAL');";
             fs.writeFileSync(scriptFileTest3,scriptContent3);
 
-            var scriptFileTest10 = fullScriptFn(10);
+            var scriptFileTest10 = fullScriptFn(10, 'blockly');
             var scriptContent10 = "console.log('" + getTestscriptName(10) + " Blockly - LOCAL');";
             fs.writeFileSync(scriptFileTest10,scriptContent10);
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -227,18 +227,17 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         var scriptFileGlobal = path.join(scriptDir, 'global', 'Global Script.js');
         expect(fs.existsSync(scriptFileGlobal)).to.be.true;
         expect(fs.readFileSync(scriptFileGlobal).toString()).to.be.equal("console.log('Global');");
-        console.log(JSON.stringify(fs.lstatSync(scriptFileGlobal)));
-        expect(fs.lstatSync(scriptFileGlobal).mtime.getUnixTime()).to.be.equal(1234567890);
+        expect(new Date(fs.lstatSync(scriptFileGlobal).mtime).getUnixTime()).to.be.equal(1234567890);
 
         var scriptFileTest1 = fullScriptFn(1);
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
-        expect(fs.lstatSync(scriptFileTest1).mtime.getUnixTime()).not.to.be.equal(1234567899);
+        expect(new Date(fs.lstatSync(scriptFileTest1).mtime).getUnixTime()).not.to.be.equal(1234567899);
 
         var scriptFileTest11 = fullScriptFn(11, 'blockly');
         expect(fs.existsSync(scriptFileTest11)).to.be.true;
         expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly');");
-        expect(new Date().getUnixTime() - fs.lstat(scriptFileTest11).mtime.getUnixTime()).to.be.less(60);
+        expect(new Date().getUnixTime() - new Date(fs.lstat(scriptFileTest11).mtime).getUnixTime()).to.be.less(60);
 
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -15,6 +15,9 @@ var adapterShortName = setup.adapterName.substring(setup.adapterName.indexOf('.'
 
 var scriptDir = path.join(__dirname, 'myScripts');
 
+function toUnixTime(t) {
+    return ~~(t / 1000);
+}
 Date.prototype.getUnixTime = Date.prototype.getCTime = function () {
     return toUnixTime(this.getTime());
 };

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -250,7 +250,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly');");
         stat = fs.lstatSync(scriptFileTest11);
         console.log(' STAT: ' + stat.mtime + ' -> ' + new Date(stat.mtime).toString() + '  --- ' + new Date(stat.mtime).getUnixTime())
-        expect(new Date().getUnixTime() - new Date(stat.mtime).getUnixTime()).to.be.less(60);
+        expect(new Date().getUnixTime() - new Date(stat.mtime).getUnixTime()).to.be.below(60);
 
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));
@@ -258,7 +258,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             expect(obj.common.engineType).to.be.equal('Javascript/js');
             expect(obj.common.mtime).to.be.equal(0);
             expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
-            expect(new Date().getUnixTime() - obj.ts).to.be.less(60);
+            expect(new Date().getUnixTime() - obj.ts).to.be.below(60);
 
             objects.getObject('script.js.tests.Test_Script_3', function(err, obj) {
                 console.log(JSON.stringify(obj));

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -227,12 +227,13 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         var scriptFileGlobal = path.join(scriptDir, 'global', 'Global Script.js');
         expect(fs.existsSync(scriptFileGlobal)).to.be.true;
         expect(fs.readFileSync(scriptFileGlobal).toString()).to.be.equal("console.log('Global');");
-        expect(fs.lstat(scriptFileGlobal).mtime.getUnixTime()).to.be.equal(1234567890);
+        console.log(JSON.stringify(fs.lstatSync(scriptFileGlobal)));
+        expect(fs.lstatSync(scriptFileGlobal).mtime.getUnixTime()).to.be.equal(1234567890);
 
         var scriptFileTest1 = fullScriptFn(1);
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
-        expect(fs.lstat(scriptFileTest1).mtime.getUnixTime()).not.to.be.equal(1234567899);
+        expect(fs.lstatSync(scriptFileTest1).mtime.getUnixTime()).not.to.be.equal(1234567899);
 
         var scriptFileTest11 = fullScriptFn(11, 'blockly');
         expect(fs.existsSync(scriptFileTest11)).to.be.true;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -109,6 +109,10 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             var scriptContent3 = "console.log('" + getTestscriptName(3) + " - LOCAL');";
             fs.writeFileSync(scriptFileTest3,scriptContent3);
 
+            var scriptFileTest10 = fullScriptFn(10);
+            var scriptContent10 = "console.log('" + getTestscriptName(10) + " Blockly - LOCAL');";
+            fs.writeFileSync(scriptFileTest10,scriptContent10);
+
             setup.setAdapterConfig(config.common, config.native);
 
             setup.startController(false, function (id, obj) {
@@ -151,7 +155,23 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                         };
                         objects.setObject(script._id, script, function (err) {
                             expect(err).to.be.not.ok;
-                            _done();
+                            script = {
+                                "common": {
+                                    "name": getTestscriptName(11),
+                                    "engineType": "Blockly",
+                                    "source": "console.log('" + getTestscriptName(11) + "');",
+                                    "enabled": true,
+                                    "engine": "system.adapter.javascript.0",
+                                    "mtime": 1
+                                },
+                                "type": "script",
+                                "_id": "script.js.tests.Test_Script_11",
+                                "native": {}
+                            };
+                            objects.setObject(script._id, script, function (err) {
+                                expect(err).to.be.not.ok;
+                                _done();
+                            });
                         });
                     });
                 });

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -236,7 +236,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         expect(fs.readFileSync(scriptFileGlobal).toString()).to.be.equal("console.log('Global');");
         var stat = fs.lstatSync(scriptFileGlobal);
         console.log(' STAT: ' + stat.mtime + ' -> ' + new Date(stat.mtime).toString() + '  --- ' + new Date(stat.mtime).getUnixTime())
-        expect(new Date(stat).getUnixTime()).to.be.equal(1234567890);
+        expect(new Date(stat.mtime).getUnixTime()).to.be.equal(1234567890);
 
         var scriptFileTest1 = fullScriptFn(1);
         expect(fs.existsSync(scriptFileTest1)).to.be.true;

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -160,7 +160,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                                 "common": {
                                     "name": getTestscriptName(11),
                                     "engineType": "Blockly",
-                                    "source": "console.log('" + getTestscriptName(11) + "');",
+                                    "source": "console.log('" + getTestscriptName(11) + " Blockly');",
                                     "enabled": true,
                                     "engine": "system.adapter.javascript.0",
                                     "mtime": 1
@@ -227,7 +227,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         var scriptFileTest11 = fullScriptFn(11, 'blockly');
         console.log('check: ' + scriptFileTest11);
         expect(fs.existsSync(scriptFileTest11)).to.be.true;
-        expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly - LOCAL');");
+        expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly');");
 
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -224,6 +224,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
         var scriptFileTest11 = fullScriptFn(11, 'blockly');
+        console.log('check: ' + scriptFileTest11);
         expect(fs.existsSync(scriptFileTest11)).to.be.true;
         expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly - LOCAL');");
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -232,21 +232,21 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));
             expect(err).to.be.null;
-            expect(obj.common.engineType).not.to.be.equal('Javascript/js');
+            expect(obj.common.engineType).to.be.equal('Javascript/js');
             expect(obj.common.mtime).not.to.be.equal(1);
             expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
 
             objects.getObject('script.js.tests.Test_Script_3', function(err, obj) {
                 console.log(JSON.stringify(obj));
                 expect(err).to.be.null;
-                expect(obj.common.engineType).not.to.be.equal('Javascript/js');
+                expect(obj.common.engineType).to.be.equal('Javascript/js');
                 expect(obj.common.mtime).not.to.be.undefined;
                 expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(3) + " - LOCAL');");
 
                 objects.getObject('script.js.tests.Test_Script_10', function(err, obj) {
                     console.log(JSON.stringify(obj));
                     expect(err).to.be.null;
-                    expect(obj.common.engineType).not.to.be.equal('Blockly');
+                    expect(obj.common.engineType).to.be.equal('Blockly');
                     expect(obj.common.mtime).not.to.be.undefined;
                     expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(10) + " Blockly - LOCAL');");
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -256,7 +256,6 @@ describe('Test ' + adapterShortName + ' adapter', function() {
             console.log(JSON.stringify(obj));
             expect(err).to.be.null;
             expect(obj.common.engineType).to.be.equal('Javascript/js');
-            expect(obj.common.mtime).to.be.equal(0);
             expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
             expect(new Date().getUnixTime() - obj.ts).to.be.below(60);
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -115,8 +115,8 @@ describe('Test ' + adapterShortName + ' adapter', function() {
 
             var scriptFileTest3 = fullScriptFn(3);
             var scriptContent3 = "console.log('" + getTestscriptName(3) + " - LOCAL');";
-            fs.writeFileSync(scriptFileTest3,scriptContent3);
             var fd = fs.openSync(scriptFileTest3, 'w');
+            fs.writeSync(fd,scriptContent3);
             fs.futimesSync(fd, 1324567890, 1324567890);
             fs.closeSync(fd);
 

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -223,19 +223,33 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         expect(fs.existsSync(path.join(scriptDir,'js2fs-settings') + '.json')).to.be.true;
         expect(fs.existsSync(scriptFileTest1)).to.be.true;
         expect(fs.readFileSync(scriptFileTest1).toString()).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
+        var scriptFileTest11 = fullScriptFn(11, 'blockly');
+        expect(fs.existsSync(scriptFileTest11)).to.be.true;
+        expect(fs.readFileSync(scriptFileTest11).toString()).to.be.equal("console.log('" + getTestscriptName(11) + " Blockly - LOCAL');");
+
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));
             expect(err).to.be.null;
+            expect(obj.common.engineType).not.to.be.equal('Javascript/js');
             expect(obj.common.mtime).not.to.be.equal(1);
             expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(1) + " - LOCAL');");
 
             objects.getObject('script.js.tests.Test_Script_3', function(err, obj) {
                 console.log(JSON.stringify(obj));
                 expect(err).to.be.null;
+                expect(obj.common.engineType).not.to.be.equal('Javascript/js');
                 expect(obj.common.mtime).not.to.be.undefined;
                 expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(3) + " - LOCAL');");
 
-                setTimeout(done, nextDelay);
+                objects.getObject('script.js.tests.Test_Script_10', function(err, obj) {
+                    console.log(JSON.stringify(obj));
+                    expect(err).to.be.null;
+                    expect(obj.common.engineType).not.to.be.equal('Blockly');
+                    expect(obj.common.mtime).not.to.be.undefined;
+                    expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(10) + " Blockly - LOCAL');");
+
+                    setTimeout(done, nextDelay);
+                });
             });
         });
     });

--- a/test/testAdapter2.js
+++ b/test/testAdapter2.js
@@ -143,12 +143,12 @@ describe('Test ' + adapterShortName + ' adapter', function() {
                                 "engineType": "Javascript/js",
                                 "source": "console.log('" + getTestscriptName(1) + "');",
                                 "enabled": true,
-                                "engine": "system.adapter.javascript.0",
-                                "mtime": 1
+                                "engine": "system.adapter.javascript.0"
                             },
                             "type": "script",
                             "_id": "script.js.tests.Test_Script_1",
-                            "native": {}
+                            "native": {},
+                            ts: 1000
                         };
                         objects.setObject(script._id, script, function (err) {
                             expect(err).to.be.not.ok;

--- a/test/testAdapter2.js
+++ b/test/testAdapter2.js
@@ -169,7 +169,6 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         onObjectChanged = function (id, obj) {
             console.log('Got initial Object-Modification for ' + id);
             if (id.substring(0,10) === 'script.js.') {
-                expect(obj.common.mtime).not.to.be.undefined;
                 changedObjects[id] = true;
                 if (Object.keys(changedObjects).length >= 1 && connectionChecked) {
                     onObjectChanged = null;
@@ -208,7 +207,7 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         objects.getObject('script.js.tests.Test_Script_1', function(err, obj) {
             console.log(JSON.stringify(obj));
             expect(err).to.be.null;
-            expect(obj.common.mtime).to.be.equal(1);
+            expect(obj.ts).to.be.equal(1000);
             expect(obj.common.source).to.be.equal("console.log('" + getTestscriptName(1) + "');");
 
             objects.getObject('script.js.tests.Test_Script_3', function(err, obj) {

--- a/test/testPackageFiles.js
+++ b/test/testPackageFiles.js
@@ -7,40 +7,84 @@ var fs        = require('fs');
 
 describe('Test package.json and io-package.json', function() {
     it('Test package files', function (done) {
-        var fileContentIOPackage = fs.readFileSync(__dirname + '/../io-package.json');
+        console.log();
+
+        var fileContentIOPackage = fs.readFileSync(__dirname + '/../io-package.json', 'utf8');
         var ioPackage = JSON.parse(fileContentIOPackage);
 
-        var fileContentNPMPackage = fs.readFileSync(__dirname + '/../package.json');
+        var fileContentNPMPackage = fs.readFileSync(__dirname + '/../package.json', 'utf8');
         var npmPackage = JSON.parse(fileContentNPMPackage);
 
         expect(ioPackage).to.be.an('object');
         expect(npmPackage).to.be.an('object');
 
-        expect(ioPackage.common.version).to.exist;
-        expect(npmPackage.version).to.exist;
+        expect(ioPackage.common.version, 'ERROR: Version number in io-package.json needs to exist').to.exist;
+        expect(npmPackage.version, 'ERROR: Version number in package.json needs to exist').to.exist;
 
-        if (!expect(ioPackage.common.version).to.be.equal(npmPackage.version)) {
-            console.log('ERROR: Version numbers in package.json and io-package.json differ!!');
-        }
+        expect(ioPackage.common.version, 'ERROR: Version numbers in package.json and io-package.json needs to match').to.be.equal(npmPackage.version);
 
         if (!ioPackage.common.news || !ioPackage.common.news[ioPackage.common.version]) {
             console.log('WARNING: No news entry for current version exists in io-package.json, no rollback in Admin possible!');
+            console.log();
         }
 
-        expect(ioPackage.common.authors).to.exist;
+        expect(npmPackage.author, 'ERROR: Author in package.json needs to exist').to.exist;
+        expect(ioPackage.common.authors, 'ERROR: Authors in io-package.json needs to exist').to.exist;
+
         if (ioPackage.common.name.indexOf('template') !== 0) {
             if (Array.isArray(ioPackage.common.authors)) {
-                expect(ioPackage.common.authors.length).to.not.be.equal(0);
+                expect(ioPackage.common.authors.length, 'ERROR: Author in io-package.json needs to be set').to.not.be.equal(0);
                 if (ioPackage.common.authors.length === 1) {
-                    expect(ioPackage.common.authors[0]).to.not.be.equal('my Name <my@email.com>');
+                    expect(ioPackage.common.authors[0], 'ERROR: Author in io-package.json needs to be a real name').to.not.be.equal('my Name <my@email.com>');
                 }
             }
             else {
-                expect(ioPackage.common.authors).to.not.be.equal('my Name <my@email.com>');
+                expect(ioPackage.common.authors, 'ERROR: Author in io-package.json needs to be a real name').to.not.be.equal('my Name <my@email.com>');
             }
         }
         else {
-            console.log('Testing for set authors field in io-package skipped because template adapter');
+            console.log('WARNING: Testing for set authors field in io-package skipped because template adapter');
+            console.log();
+        }
+        expect(fs.existsSync(__dirname + '/../README.md'), 'ERROR: README.md needs to exist! Please create one with description, detail information and changelog. English is mandatory.').to.be.true;
+        if (!ioPackage.common.titleLang || typeof ioPackage.common.titleLang !== 'object') {
+            console.log('WARNING: titleLang is not existing in io-package.json. Please add');
+            console.log();
+        }
+        if (
+            ioPackage.common.title.indexOf('iobroker') !== -1 ||
+            ioPackage.common.title.indexOf('ioBroker') !== -1 ||
+            ioPackage.common.title.indexOf('adapter') !== -1 ||
+            ioPackage.common.title.indexOf('Adapter') !== -1
+        ) {
+            console.log('WARNING: title contains Adapter or ioBroker. It is clear anyway, that it is adapter for ioBroker.');
+            console.log();
+        }
+
+        if (ioPackage.common.name.indexOf('vis-') !== 0) {
+            if (!ioPackage.common.materialize || !fs.existsSync(__dirname + '/../admin/index_m.html') || !fs.existsSync(__dirname + '/../gulpfile.js')) {
+                console.log('WARNING: Admin3 support is missing! Please add it');
+                console.log();
+            }
+            if (ioPackage.common.materialize) {
+                expect(fs.existsSync(__dirname + '/../admin/index_m.html'), 'Admin3 support is enabled in io-package.json, but index_m.html is missing!').to.be.true;
+            }
+        }
+
+        var licenseFileExists = fs.existsSync(__dirname + '/../LICENSE');
+        var fileContentReadme = fs.readFileSync(__dirname + '/../README.md', 'utf8');
+        if (fileContentReadme.indexOf('## Changelog') === -1) {
+            console.log('Warning: The README.md should have a section ## Changelog');
+            console.log();
+        }
+        expect((licenseFileExists || fileContentReadme.indexOf('## License') !== -1), 'A LICENSE must exist as LICENSE file or as part of the README.md').to.be.true;
+        if (!licenseFileExists) {
+            console.log('Warning: The License should also exist as LICENSE file');
+            console.log();
+        }
+        if (fileContentReadme.indexOf('## License') === -1) {
+            console.log('Warning: The README.md should also have a section ## License to be shown in Admin3');
+            console.log();
         }
         done();
     });

--- a/test/testPackageFiles.js
+++ b/test/testPackageFiles.js
@@ -2,18 +2,20 @@
 /* jshint strict:false */
 /* jslint node: true */
 /* jshint expr: true */
-var expect = require('chai').expect;
-var fs        = require('fs');
+'use strict';
 
-describe('Test package.json and io-package.json', function() {
-    it('Test package files', function (done) {
+const expect = require('chai').expect;
+const fs     = require('fs');
+
+describe('Test package.json and io-package.json', () => {
+    it('Test package files', done => {
         console.log();
 
-        var fileContentIOPackage = fs.readFileSync(__dirname + '/../io-package.json', 'utf8');
-        var ioPackage = JSON.parse(fileContentIOPackage);
+        const fileContentIOPackage = fs.readFileSync(__dirname + '/../io-package.json', 'utf8');
+        const ioPackage = JSON.parse(fileContentIOPackage);
 
-        var fileContentNPMPackage = fs.readFileSync(__dirname + '/../package.json', 'utf8');
-        var npmPackage = JSON.parse(fileContentNPMPackage);
+        const fileContentNPMPackage = fs.readFileSync(__dirname + '/../package.json', 'utf8');
+        const npmPackage = JSON.parse(fileContentNPMPackage);
 
         expect(ioPackage).to.be.an('object');
         expect(npmPackage).to.be.an('object');
@@ -30,6 +32,8 @@ describe('Test package.json and io-package.json', function() {
 
         expect(npmPackage.author, 'ERROR: Author in package.json needs to exist').to.exist;
         expect(ioPackage.common.authors, 'ERROR: Authors in io-package.json needs to exist').to.exist;
+
+        expect(ioPackage.common.license, 'ERROR: License missing in io-package in common.license').to.exist;
 
         if (ioPackage.common.name.indexOf('template') !== 0) {
             if (Array.isArray(ioPackage.common.authors)) {
@@ -61,7 +65,7 @@ describe('Test package.json and io-package.json', function() {
             console.log();
         }
 
-        if (ioPackage.common.name.indexOf('vis-') !== 0) {
+        if (!ioPackage.common.controller && !ioPackage.common.onlyWWW && !ioPackage.common.noConfig) {
             if (!ioPackage.common.materialize || !fs.existsSync(__dirname + '/../admin/index_m.html') || !fs.existsSync(__dirname + '/../gulpfile.js')) {
                 console.log('WARNING: Admin3 support is missing! Please add it');
                 console.log();
@@ -71,8 +75,8 @@ describe('Test package.json and io-package.json', function() {
             }
         }
 
-        var licenseFileExists = fs.existsSync(__dirname + '/../LICENSE');
-        var fileContentReadme = fs.readFileSync(__dirname + '/../README.md', 'utf8');
+        const licenseFileExists = fs.existsSync(__dirname + '/../LICENSE');
+        const fileContentReadme = fs.readFileSync(__dirname + '/../README.md', 'utf8');
         if (fileContentReadme.indexOf('## Changelog') === -1) {
             console.log('Warning: The README.md should have a section ## Changelog');
             console.log();


### PR DESCRIPTION
- updated base testing files
- updated base files
- use official timestamp from object that is availabe in iobroker since js-controller 1.2.1 or alternatove use "ts" instead of mtime.
- fixes #24 and #23

After you accepted it I would ask in Forum for some more testers and then we could do a 1.0.0 :-)